### PR TITLE
replace "is not *undefined*" by "is present"

### DIFF
--- a/spec/finalization-registry.html
+++ b/spec/finalization-registry.html
@@ -4,7 +4,7 @@
   <emu-alg>
     1. Let _finalizationRegistry_ be the *this* value.
     1. Perform ? RequireInternalSlot(_finalizationRegistry_, [[Cells]]).
-    1. If _callback_ is not *undefined* and IsCallable(_callback_) is
+    1. If _callback_ is present and IsCallable(_callback_) is
     *false*, throw a *TypeError* exception.
     1. Perform ? CleanupFinalizationRegistry(_finalizationRegistry_, _callback_).
     1. Return *undefined*.


### PR DESCRIPTION
I think that it's better to check for presence since IsCallable already implicitly checks for undefined too. This is also the wording used in spec (in some parts) and in WeakRefs PR draft